### PR TITLE
Fix .travis.yml requirements install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
     - git clone https://github.com/armmbed/mbed-os.git
     - git clone https://github.com/armmbed/spiflash-driver.git
       # Install python dependencies
-    - sudo pip install -r mbed-os/requirements.txt
+    - pip install -r mbed-os/requirements.txt
       # Create main file for example
     - sed -n '/``` c++/,/```/{/```/d; p;}' README.md > main.cpp


### PR DESCRIPTION
Recently, how pip installs dependencies in travis has changed.
Now, installing dependecies with sudo prevents import in user space.